### PR TITLE
Use 2 commands to teleport player in servers, and add the ForgeUpdateCheck 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-build_mod: copy_assets build_lang
+build_mod: copy_assets
+	mkdir -p src/main/resources/assets/aperture/lang
 	./gradlew build
 
 copy_assets:
@@ -10,7 +11,7 @@ copy_assets:
 
 build_lang:
 	mkdir -p src/main/resources/assets/aperture/lang
-	php php/help.php
+	./gradlew buildLangFiles
 
 check: build_lang
 	php php/language.php

--- a/help/en_US/config.yml
+++ b/help/en_US/config.yml
@@ -3,7 +3,7 @@ aperture.config:
     camera:
         title: Camera
         tooltip: General camera options
-        
+
         camera_duration_step: Duration step
         camera_duration: Default fixture duration
         camera_interpolate_target: Interpolate target fixtures
@@ -18,21 +18,24 @@ aperture.config:
         camera_first_tick_zero: First tick zero
         camera_debug_ticks: Debug ticks
         camera_profile_render: Render camera profile
-        
+
         gui_render_mouse: Render mouse cursor in GUIs
-        
+
+        minecrafttp_teleport: Use /minecraft:tp
+        tp_teleport: Use /tp
+
     smooth:
         title: Smooth camera
         tooltip: Smooth camera options
-        
+
         camera_smooth_clamp: Limit pitch
-        
+
         roll_speed: Roll speed
         roll_friction: Roll friction
-        
+
         fov_speed: FOV speed
         fov_friction: FOV friction
-        
+
         smooth_enabled: Smooth camera enabled
         mouse_x_friction: Mouse Y friction
         mouse_y_friction: Mouse Y friction

--- a/help/en_US/config_comments.yml
+++ b/help/en_US/config_comments.yml
@@ -15,18 +15,21 @@ aperture.config.comments:
         camera_debug_ticks: Write current camera playback tick to the log
         camera_first_tick_zero: When camera runner starts, start the actual playback when partial tick is exactly zero
         camera_profile_render: Render camera profile in the world?
-        
+
         gui_render_mouse: Render on the screen a texture of a mouse pointer during GUI
-        
+
+        minecrafttp_teleport: When start the camera playback in multiplayer, teleport you with /minecraft:tp command (For Essentials)
+        tp_teleport: When start the camera playback in multiplayer, teleport you with /tp command (For Vanilla or Forge)
+
     smooth:
         camera_smooth_clamp: Clip smooth camera's pitch between -90 and 90 degrees range? WUB WUB WUB
-        
+
         roll_speed: Roll acceleration speed
         roll_friction: Roll acceleration friction (how fast it slows down)
-        
+
         fov_speed: FOV acceleration speed
         fov_friction: FOV acceleration friction (how fast it slows down)
-        
+
         smooth_enabled: Enable smooth camera. WUB WUB WUB
         mouse_x_friction: Smooth mouse X friction
         mouse_y_friction: Smooth mouse Y friction

--- a/help/en_US/gui.yml
+++ b/help/en_US/gui.yml
@@ -22,13 +22,15 @@ aperture.gui:
 
     config:
         title: Camera Options
-        
+
         minema: Minema
         spectator: Spectator
         show_path: Show path
         sync: Sync (S)
         flight: Flight mode (F)
         display_info: Display position
+        minecrafttp_teleport: Use /minecraft:tp
+        tp_teleport: Use /tp
 
     tooltips:
         jump_next_fixture: Jump to next fixture (Shift + Right)
@@ -60,11 +62,11 @@ aperture.gui:
         look: Look
         follow: Follow
         circular: Circular
-        
+
     modifiers:
         title: Modifiers
         select: Select camera fixture...
-        
+
         shake: Shake
         math: Math
         look: Look
@@ -72,13 +74,13 @@ aperture.gui:
         translate: Translate
         angle: Angle
         orbit: Orbit
-        
+
         panels:
             copy_entity: Copy entity
-            
+
             shake: Shake
             shake_amount: Amount
-            
+
             relative: Relative?
             at_block: Look at block?
 

--- a/help/zh_CN/commands.yml
+++ b/help/zh_CN/commands.yml
@@ -35,12 +35,12 @@ aperture.commands:
             |
                 {l}{6}/{r}camera {8}new{r} {7}<client|server> <filename>{r}
 
-                {r}新建文件名为 {7}<filename>{r} 的相机配置文件到 {7}client(客户端){r} 或 {7}server(服务器){r}。
+                {r}新建文件名为 {7}<filename>{r} 的相机配置文件到 {7}client（客户端）{r} 或 {7}server（服务器）{r}。
         load:
             |
                 {l}{6}/{r}camera {8}load{r} {7}<client|server> <filename>{r}
 
-                {r}从 {7}client(客户端) {r} 或者 {7}server(服务器){r} 加载文件名为 {7}<filename>{r} 的相机配置文件。
+                {r}从 {7}client（客户端） {r} 或者 {7}server（服务器）{r} 加载文件名为 {7}<filename>{r} 的相机配置文件。
         save:
             |
                 {l}{6}/{r}camera {8}save{r} {7}[filename]{r}
@@ -50,18 +50,18 @@ aperture.commands:
             |
                 {l}{6}/{r}camera {8}clear{r}
 
-                {r}清除相机配置文件 (会移除所有相机关键点)
+                {r}清除相机配置文件 （会移除所有相机关键点）
         goto:
             |
                 {l}{6}/{r}camera {8}goto{r} {7}<index> [progress]{r}
 
-                {r}传送你到索引 {7}<index>{r} 的相机关键点。你可以选择指定 {7}[progress]{r}(路程) (从 {7}0.0{r} 到 {7}1.0{r}) 这会允许你传送到相机路程的中间或者环绕点。
+                {r}传送你到索引 {7}<index>{r} 的相机关键点。你可以选择指定 {7}[progress]{r}（路程） （从 {7}0.0{r} 到 {7}1.0{r}） 这会允许你传送到相机路程的中间或者环绕点。
 
         default:
             |
                 {l}{6}/{r}camera {8}default{r}
 
-                {r}恢复相机的 {7}FOV{r} 和 {7}翻滚角度{r} 到默认设置({7}FOV 70.0{r} 和 {7}0.0{r} 度).
+                {r}恢复相机的 {7}FOV{r} 和 {7}翻滚角度{r} 到默认设置（{7}FOV 70.0{r} 和 {7}0.0{r} 度）.
         fov:
             |
                 {l}{6}/{r}camera {8}fov{r} {7}[fov]{r}
@@ -71,7 +71,7 @@ aperture.commands:
             |
                 {l}{6}/{r}camera {8}roll{r} {7}[roll]{r}
 
-                {r}设定客户端相机的 {7}[roll]{r} ({7}Z轴{r}翻滚程度)。
+                {r}设定客户端相机的 {7}[roll]{r} （{7}Z轴{r}翻滚程度）。
 
         rotate:
             |
@@ -106,7 +106,7 @@ aperture.commands:
                 |
                     {l}{6}/{r}camera {8}duration{r} {7}[index] [duration]{r}
 
-                    {r}可以用来设置，或者获取整个相机配置或一个相机关键点的时长。如果所有的参数按照预设，命令会设置{7}[duration]{r} (tick单位)时长到索引号 {7}[index]{r} 的相机关键点。增减符号可以用在 {7}[duration]{r} 参数。
+                    {r}可以用来设置，或者获取整个相机配置或一个相机关键点的时长。如果所有的参数按照预设，命令会设置 {7}[duration]{r}（tick单位）时长到索引号 {7}[index]{r} 的相机关键点。增减符号可以用在 {7}[duration]{r} 参数。
 
             move:
                 |
@@ -121,7 +121,7 @@ aperture.commands:
                 |
                     {l}{6}/{r}camera path {8}add{r} {7}<index> [before_point]{r}
 
-                    {r}在索引号 {7}<index>{r} 的后面添加一个路径点，或者在指定 {7}[before_point]{r} 编号的前面(如果指定了)。
+                    {r}在索引号 {7}<index>{r} 的后面添加一个路径点，或者在指定 {7}[before_point]{r} 编号的前面（如果指定了）。
 
             edit:
                 |

--- a/help/zh_CN/config.yml
+++ b/help/zh_CN/config.yml
@@ -15,11 +15,14 @@ aperture.config:
         camera_path_default_interp: 默认插入路径类型
         camera_command_name: 相机命令名称
         camera_simulate_velocity: 模拟速率
-        camera_first_tick_zero: 第一帧为0
+        camera_first_tick_zero: 第一帧为 0
         camera_debug_ticks: Debug ticks
         camera_profile_render: 渲染相机配置
 
-        gui_render_mouse: 在GUI中渲染出鼠标指针
+        gui_render_mouse: 在 GUI 中渲染出鼠标指针
+
+        minecrafttp_teleport: 使用 /minecraft:tp
+        tp_teleport: 使用 /tp
 
     smooth:
         title: 平滑相机
@@ -34,5 +37,5 @@ aperture.config:
         fov_friction: FOV 摩擦力
 
         smooth_enabled: 开启平滑相机
-        mouse_x_friction: 鼠标X轴摩擦力
-        mouse_y_friction: 鼠标Y轴摩擦力
+        mouse_x_friction: 鼠标 X 轴摩擦力
+        mouse_y_friction: 鼠标 Y 轴摩擦力

--- a/help/zh_CN/config_comments.yml
+++ b/help/zh_CN/config_comments.yml
@@ -3,7 +3,7 @@ aperture.config.comments:
     camera:
         camera_duration_step: 当使用快捷键改变关键点时长时，一次会增加/减少多少？（tick）
         camera_duration: 相机关键点的默认时长有多久？（tick）
-        camera_interpolate_target: 插入目标为基础（follow和look）的相机关键点的结果
+        camera_interpolate_target: 插入目标为基础（follow 和 look）的相机关键点的结果
         camera_interpolate_target_value: 插入目标为基础相机关键点的值
         camera_spectator: 当开始播放相机回放时切换到旁观模式？
         camera_step_factor: 为路径帧提供的相机路径参数
@@ -12,21 +12,24 @@ aperture.config.comments:
         camera_path_default_interp: 插入路径时，路径的默认类型
         camera_command_name: 允许你重新绑定相机命令的名字（需要重启游戏来生效）
         camera_simulate_velocity: 在回放时模拟玩家走动摇摆（从腿的角度）
-        camera_debug_ticks: 将目前播放的tick时间写入日志文件
+        camera_debug_ticks: 将目前播放的 tick 时间写入日志文件
         camera_first_tick_zero: 当相机播放时将当前帧归零
         camera_profile_render: 在世界中渲染出相机配置？
 
-        gui_render_mouse: 在打开GUI的时候渲染出鼠标的材质
+        gui_render_mouse: 在打开 GUI 的时候渲染出鼠标的材质
+
+        minecrafttp_teleport: 当在多人游戏时开始相机回放，使用 /minecraft:tp 来瞬移（针对于安装了 Essentials 插件的服务器）
+        tp_teleport: 当在多人游戏时开始相机回放，使用 /tp 来瞬移（针对于原版和 Forge 等服务器）
 
     smooth:
-        camera_smooth_clamp: 在－90和90度之间，修剪平滑相机的俯仰程度？嗡!嗡!嗡!
+        camera_smooth_clamp: 在 －90 和 90 度之间，修剪平滑相机的俯仰程度？嗡!嗡!嗡!
 
         roll_speed: 倾斜加速速度
         roll_friction: 倾斜加速摩擦力（慢下来有多快）
 
-        fov_speed: FOV加速速度
-        fov_friction: FOV加速摩擦力（慢下来有多快）
+        fov_speed: FOV 加速速度
+        fov_friction: FOV 加速摩擦力（慢下来有多快）
 
         smooth_enabled: 开启平滑相机。嗡!嗡!嗡!
-        mouse_x_friction: 鼠标平滑X轴摩擦力
-        mouse_y_friction: 鼠标平滑Y轴摩擦力
+        mouse_x_friction: 鼠标平滑 X 轴摩擦力
+        mouse_y_friction: 鼠标平滑 Y 轴摩擦力

--- a/help/zh_CN/gui.yml
+++ b/help/zh_CN/gui.yml
@@ -29,6 +29,8 @@ aperture.gui:
         sync: 同步（S）
         flight: 飞行模式（F）
         display_info: 显示位置
+        minecrafttp_teleport: 使用 /minecraft:tp
+        tp_teleport: 使用 /tp
 
     tooltips:
         jump_next_fixture: 跳到下一个关键点（Shift + 右）

--- a/help/zh_CN/gui.yml
+++ b/help/zh_CN/gui.yml
@@ -26,26 +26,26 @@ aperture.gui:
         minema: Minema
         spectator: 观看者
         show_path: 显示路径
-        sync: 同步 (S)
-        flight: 飞行模式 (F)
+        sync: 同步（S）
+        flight: 飞行模式（F）
         display_info: 显示位置
 
     tooltips:
-        jump_next_fixture: 跳到下一个关键点 (Shift + 右)
-        jump_next_frame: 跳到下一帧 (右)
-        plause: 播放/暂停 (空格)
-        jump_prev_frame: 跳到上一帧 (左)
-        jump_prev_fixture: 跳到上一个关键点 (Shift + 左)
+        jump_next_fixture: 跳到下一个关键点（Shift + 右）
+        jump_next_frame: 跳到下一帧（右）
+        plause: 播放/暂停（空格）
+        jump_prev_frame: 跳到上一帧（左）
+        jump_prev_fixture: 跳到上一个关键点（Shift + 左）
 
         move_up: 将关键点向前移动
-        move_duration: 将持续时间移动到光标 (M)
-        copy_position: 拷贝玩家的位置 (B)
+        move_duration: 将持续时间移动到光标（M）
+        copy_position: 拷贝玩家的位置（B）
         move_down: 将关键点向后移动
 
-        save: 保存相机配置 (Ctrl+S)
+        save: 保存相机配置（Ctrl+S）
         profiles: 显示相机配置
         config: 显示相机编辑器选项
-        modifiers: 打开调整器面板 (O)
+        modifiers: 打开调整器面板（O）
         goto: 前往指定的帧
         add: 添加关键点
         remove: 移除选择的关键点
@@ -78,8 +78,8 @@ aperture.gui:
 
             shake: 摇晃
             shake_amount: 数量值
-            
-            relative: 父级？
+
+            relative: 是绝对的？
             at_block: 看着方块？
 
     profiles:

--- a/help/zh_CN/info.yml
+++ b/help/zh_CN/info.yml
@@ -3,20 +3,20 @@ aperture.info:
     camera:
         duration:
             fixture: "{f}在索引 %s{f} 的相机关键点持续时长为 %s{f} ticks。"
-            profile: "{f}摄像机配置时长为%s{f} ticks，并且有%s{f}个关键点。"
-        
+            profile: "{f}摄像机配置时长为 %s{f} ticks，并且有 %s{f} 个关键点。"
+
         # Camera roll and fov
-        fov: "{f}你的FOV为%s{f}度。"
-        roll: "{f}你的倾斜度为%s{f}度。"
-    
+        fov: "{f}你的 FOV 为 %s{f} 度。"
+        roll: "{f}你的倾斜度为 %s{f} 度。"
+
     # General command infos
     commands:
         load_chunks: "{f}已加载在渲染范围里的已创建区块。"
-        
+
         replace_texture: "{f}材质 %s{f} 已被材质 %s{f} 替换。"
         restore_texture: "{f}材质 %s{f} 已经还原为初始状态。"
 
-    
+
     # Camera profile
     profile:
         new: "{f}已创建一个新的相机配置文件，命名为 %s{f}。"

--- a/help/zh_CN/keys.yml
+++ b/help/zh_CN/keys.yml
@@ -2,33 +2,33 @@
 key.aperture:
     # Categories
     misc: Aperture
-    camera: Aperture 翻滚和FOV
-    
+    camera: Aperture 翻滚和 FOV
+
     camera_editor: 相机编辑器
     smooth_camera: 平滑相机
 
     # Camera control
-    control: 
+    control:
         title: Aperture 控制
-        
+
         stepUp: 向上移动
         stepDown: 向下移动
         stepLeft: 向左移动
         stepRight: 向右移动
         stepFront: 向前移动
         stepBack: 向后移动
-        
+
         rotateUp: 视角向上
         rotateDown: 视角向下
         rotateLeft: 视角向左
         rotateRight: 视角向右
-    
+
     # Roll controlling keys
     roll:
         add: 顺时针翻滚
         reduce: 逆时针翻滚
         reset: 重设翻滚
-    
+
     # Roll controlling keys
     fov:
         add: 增大 FOV

--- a/src/main/java/mchorse/aperture/Aperture.java
+++ b/src/main/java/mchorse/aperture/Aperture.java
@@ -19,7 +19,7 @@ import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
  *
  * This mod provides a lot of tools related to camera.
  */
-@Mod(modid = Aperture.MODID, name = Aperture.MODNAME, version = Aperture.VERSION, guiFactory = Aperture.GUI_FACTORY, updateJSON = "https://raw.githubusercontent.com/ycwei982/aperture/master/version.json")
+@Mod(modid = Aperture.MODID, name = Aperture.MODNAME, version = Aperture.VERSION, guiFactory = Aperture.GUI_FACTORY, updateJSON = "https://raw.githubusercontent.com/mchorse/aperture/master/version.json")
 public class Aperture
 {
     /* Mod info */

--- a/src/main/java/mchorse/aperture/Aperture.java
+++ b/src/main/java/mchorse/aperture/Aperture.java
@@ -12,14 +12,14 @@ import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 
 /**
  * Main entry point of Aperture
- * 
- * This mod allows people to create Minecraft cinematics. It provides tools for 
- * managing camera profiles and camera fixtures withing camera profiles via 
+ *
+ * This mod allows people to create Minecraft cinematics. It provides tools for
+ * managing camera profiles and camera fixtures withing camera profiles via
  * command line (chat commands) or GUI (camera editor).
- * 
+ *
  * This mod provides a lot of tools related to camera.
  */
-@Mod(modid = Aperture.MODID, name = Aperture.MODNAME, version = Aperture.VERSION, guiFactory = Aperture.GUI_FACTORY)
+@Mod(modid = Aperture.MODID, name = Aperture.MODNAME, version = Aperture.VERSION, guiFactory = Aperture.GUI_FACTORY, updateJSON = "https://raw.githubusercontent.com/ycwei982/aperture/master/version.json")
 public class Aperture
 {
     /* Mod info */

--- a/src/main/java/mchorse/aperture/camera/CameraRunner.java
+++ b/src/main/java/mchorse/aperture/camera/CameraRunner.java
@@ -293,8 +293,16 @@ public class CameraRunner
 
                 if (dx * dx + dy * dy + dz * dz >= 10 * 10)
                 {
-                    this.mc.thePlayer.sendChatMessage("/tp " + point.x + " " + point.y + " " + point.z + " " + angle.yaw + " " + angle.pitch);
-                    this.mc.thePlayer.sendChatMessage("/tppos " + point.x + " " + point.y + " " + point.z + " " + angle.yaw + " " + angle.pitch);
+                    /* Make it compatible with Essentials plugin, which replaced the native /tp command */
+                    if(Aperture.proxy.config.minecrafttp_teleport)
+                    {
+                        this.mc.thePlayer.sendChatMessage("/minecraft:tp " + point.x + " " + point.y + " " + point.z + " " + angle.yaw + " " + angle.pitch);
+                    }
+                    if(Aperture.proxy.config.tp_teleport)
+                    {
+                        this.mc.thePlayer.sendChatMessage("/tp " + point.x + " " + point.y + " " + point.z + " " + angle.yaw + " " + angle.pitch);
+                    }
+
                 }
             }
 

--- a/src/main/java/mchorse/aperture/camera/CameraRunner.java
+++ b/src/main/java/mchorse/aperture/camera/CameraRunner.java
@@ -30,7 +30,7 @@ public class CameraRunner
     private Minecraft mc = Minecraft.getMinecraft();
 
     /**
-     * FOV used before camera playback 
+     * FOV used before camera playback
      */
     private float fov = 70.0F;
 
@@ -40,37 +40,37 @@ public class CameraRunner
     private GameType gameMode = GameType.NOT_SET;
 
     /**
-     * Whether it's first tick during the playback 
+     * Whether it's first tick during the playback
      */
     private boolean firstTick = false;
 
     /**
-     * Is camera runner waits for 0.0 partial tick 
+     * Is camera runner waits for 0.0 partial tick
      */
     private boolean firstTickZero = false;
 
     /**
-     * Whether partial tick 0.0 was detected 
+     * Whether partial tick 0.0 was detected
      */
     private boolean firstTickZeroStart = false;
 
     /**
-     * Is camera runner running? 
+     * Is camera runner running?
      */
     private boolean isRunning = false;
 
     /**
-     * The duration of camera profile 
+     * The duration of camera profile
      */
     private long duration;
 
     /**
-     * Camera profile which is getting currently played 
+     * Camera profile which is getting currently played
      */
     private CameraProfile profile;
 
     /**
-     * Position used to apply fixtures and modifiers upon 
+     * Position used to apply fixtures and modifiers upon
      */
     private Position position = new Position(0, 0, 0, 0, 0);
 
@@ -110,7 +110,7 @@ public class CameraRunner
     }
 
     /**
-     * Start the profile runner from the first tick 
+     * Start the profile runner from the first tick
      */
     public void start(CameraProfile profile)
     {
@@ -157,7 +157,7 @@ public class CameraRunner
     }
 
     /**
-     * Get game mode of the given player 
+     * Get game mode of the given player
      */
     public GameType getGameMode(EntityPlayer player)
     {
@@ -167,7 +167,7 @@ public class CameraRunner
     }
 
     /**
-     * Stop playback of camera profile 
+     * Stop playback of camera profile
      */
     public void stop()
     {
@@ -293,7 +293,8 @@ public class CameraRunner
 
                 if (dx * dx + dy * dy + dz * dz >= 10 * 10)
                 {
-                    this.mc.thePlayer.sendChatMessage("/minecraft:tp " + point.x + " " + point.y + " " + point.z + " " + angle.yaw + " " + angle.pitch);
+                    this.mc.thePlayer.sendChatMessage("/tp " + point.x + " " + point.y + " " + point.z + " " + angle.yaw + " " + angle.pitch);
+                    this.mc.thePlayer.sendChatMessage("/tppos " + point.x + " " + point.y + " " + point.z + " " + angle.yaw + " " + angle.pitch);
                 }
             }
 
@@ -309,17 +310,17 @@ public class CameraRunner
 
     /**
      * Set player position
-     * 
-     * This method is responsible for setting player's position and rotation. 
-     * Why are these two methods invoked? Good question. 
-     * 
-     * {@link EntityPlayer#setLocationAndAngles(double, double, double, float, float)} 
-     * updates some client side values such as lastTick* and prevPos* values, 
-     * which makes the transition between two distant cameras, seamless, meanwhile 
-     * {@link EntityPlayer#setPositionAndRotation(double, double, double, float, float)} 
+     *
+     * This method is responsible for setting player's position and rotation.
+     * Why are these two methods invoked? Good question.
+     *
+     * {@link EntityPlayer#setLocationAndAngles(double, double, double, float, float)}
+     * updates some client side values such as lastTick* and prevPos* values,
+     * which makes the transition between two distant cameras, seamless, meanwhile
+     * {@link EntityPlayer#setPositionAndRotation(double, double, double, float, float)}
      * is responsible for fixing/clamping player's rotation.
-     * 
-     * By using only one of these methods wouldn't guarantee supreme quality of 
+     *
+     * By using only one of these methods wouldn't guarantee supreme quality of
      * the camera animation.
      */
     public void setPlayerPosition(EntityPlayer player, double x, double y, double z, Angle angle)

--- a/src/main/java/mchorse/aperture/camera/CameraRunner.java
+++ b/src/main/java/mchorse/aperture/camera/CameraRunner.java
@@ -293,7 +293,7 @@ public class CameraRunner
 
                 if (dx * dx + dy * dy + dz * dz >= 10 * 10)
                 {
-                    this.mc.thePlayer.sendChatMessage("/tp " + point.x + " " + point.y + " " + point.z + " " + angle.yaw + " " + angle.pitch);
+                    this.mc.thePlayer.sendChatMessage("/minecraft:tp " + point.x + " " + point.y + " " + point.z + " " + angle.yaw + " " + angle.pitch);
                 }
             }
 

--- a/src/main/java/mchorse/aperture/client/gui/config/GuiConfigCameraOptions.java
+++ b/src/main/java/mchorse/aperture/client/gui/config/GuiConfigCameraOptions.java
@@ -20,6 +20,8 @@ public class GuiConfigCameraOptions extends AbstractGuiConfigOptions
     public GuiCheckBox sync;
     public GuiCheckBox flight;
     public GuiCheckBox displayPosition;
+    public GuiCheckBox minecrafttpTeleport;
+    public GuiCheckBox tpTeleport;
 
     public int max;
     public int x;
@@ -58,6 +60,19 @@ public class GuiConfigCameraOptions extends AbstractGuiConfigOptions
         this.buttons.add(this.sync);
         this.buttons.add(this.flight);
         this.buttons.add(this.displayPosition);
+
+        /* Show two tp commands' options if in multiplayer */
+        if (!Minecraft.getMinecraft().isSingleplayer())
+        {
+            this.minecrafttpTeleport = new GuiCheckBox(-7, 0, 0, I18n.format("aperture.gui.config.minecrafttp_teleport"), Aperture.proxy.config.minecrafttp_teleport);
+            this.minecrafttpTeleport.packedFGColour = 0xffffff;
+
+            this.tpTeleport = new GuiCheckBox(-8, 0, 0, I18n.format("aperture.gui.config.tp_teleport"), Aperture.proxy.config.tp_teleport);
+            this.tpTeleport.packedFGColour = 0xffffff;
+
+            this.buttons.add(this.minecrafttpTeleport);
+            this.buttons.add(this.tpTeleport);
+        }
 
         for (GuiButton button : this.buttons.buttons)
         {
@@ -103,6 +118,12 @@ public class GuiConfigCameraOptions extends AbstractGuiConfigOptions
         this.sync.setIsChecked(this.editor.syncing);
         this.flight.setIsChecked(this.editor.flight.enabled);
         this.displayPosition.setIsChecked(this.editor.displayPosition);
+
+        if (this.minecrafttpTeleport != null)
+        {
+            this.minecrafttpTeleport.setIsChecked(Aperture.proxy.config.minecrafttp_teleport);
+            this.tpTeleport.setIsChecked(Aperture.proxy.config.tp_teleport);
+        }
     }
 
     @Override
@@ -149,6 +170,20 @@ public class GuiConfigCameraOptions extends AbstractGuiConfigOptions
         else if (id == -6)
         {
             this.editor.displayPosition = !this.editor.displayPosition;
+        }
+        else if (id == -7)
+        {
+            Property prop = Aperture.proxy.forge.getCategory("camera").get("minecrafttp_teleport");
+
+            prop.set(this.minecrafttpTeleport.isChecked());
+            save = true;
+        }
+        else if (id == -8)
+        {
+            Property prop = Aperture.proxy.forge.getCategory("camera").get("tp_teleport");
+
+            prop.set(this.tpTeleport.isChecked());
+            save = true;
         }
 
         if (save)

--- a/src/main/java/mchorse/aperture/client/gui/config/GuiConfigCameraOptions.java
+++ b/src/main/java/mchorse/aperture/client/gui/config/GuiConfigCameraOptions.java
@@ -5,6 +5,7 @@ import mchorse.aperture.ClientProxy;
 import mchorse.aperture.client.gui.GuiCameraEditor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.resources.I18n;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.client.config.GuiCheckBox;
@@ -30,15 +31,9 @@ public class GuiConfigCameraOptions extends AbstractGuiConfigOptions
     public GuiConfigCameraOptions(GuiCameraEditor editor)
     {
         super(editor);
-
-        /* Don't show that if Minema mod isn't present */
-        if (Loader.isModLoaded("minema"))
-        {
-            this.minema = new GuiCheckBox(-1, 0, 0, I18n.format("aperture.gui.config.minema"), Aperture.proxy.config.camera_minema);
-            this.minema.packedFGColour = 0xffffff;
-
-            this.buttons.add(this.minema);
-        }
+        
+        this.minema = new GuiCheckBox(-1, 0, 0, I18n.format("aperture.gui.config.minema"), Aperture.proxy.config.camera_minema);
+        this.minema.packedFGColour = 0xffffff;
 
         this.spectator = new GuiCheckBox(-2, 0, 0, I18n.format("aperture.gui.config.spectator"), Aperture.proxy.config.camera_spectator);
         this.spectator.packedFGColour = 0xffffff;
@@ -54,30 +49,13 @@ public class GuiConfigCameraOptions extends AbstractGuiConfigOptions
 
         this.displayPosition = new GuiCheckBox(-6, 0, 0, I18n.format("aperture.gui.config.display_info"), this.editor.displayPosition);
         this.displayPosition.packedFGColour = 0xffffff;
+        
+        this.minecrafttpTeleport = new GuiCheckBox(-7, 0, 0, I18n.format("aperture.gui.config.minecrafttp_teleport"), Aperture.proxy.config.minecrafttp_teleport);
+        this.minecrafttpTeleport.packedFGColour = 0xffffff;
 
-        this.buttons.add(this.spectator);
-        this.buttons.add(this.renderPath);
-        this.buttons.add(this.sync);
-        this.buttons.add(this.flight);
-        this.buttons.add(this.displayPosition);
-
-        /* Show two tp commands' options if in multiplayer */
-        if (!Minecraft.getMinecraft().isSingleplayer())
-        {
-            this.minecrafttpTeleport = new GuiCheckBox(-7, 0, 0, I18n.format("aperture.gui.config.minecrafttp_teleport"), Aperture.proxy.config.minecrafttp_teleport);
-            this.minecrafttpTeleport.packedFGColour = 0xffffff;
-
-            this.tpTeleport = new GuiCheckBox(-8, 0, 0, I18n.format("aperture.gui.config.tp_teleport"), Aperture.proxy.config.tp_teleport);
-            this.tpTeleport.packedFGColour = 0xffffff;
-
-            this.buttons.add(this.minecrafttpTeleport);
-            this.buttons.add(this.tpTeleport);
-        }
-
-        for (GuiButton button : this.buttons.buttons)
-        {
-            this.max = Math.max(this.max, button.width);
-        }
+        this.tpTeleport = new GuiCheckBox(-8, 0, 0, I18n.format("aperture.gui.config.tp_teleport"), Aperture.proxy.config.tp_teleport);
+        this.tpTeleport.packedFGColour = 0xffffff;
+          
     }
 
     @Override
@@ -96,6 +74,31 @@ public class GuiConfigCameraOptions extends AbstractGuiConfigOptions
     public void update(int x, int y)
     {
         int i = 0;
+        this.buttons.clear();
+        
+        /* Don't show that if Minema mod isn't present */
+        if (Loader.isModLoaded("minema"))
+        {
+            this.buttons.add(this.minema);
+        }
+
+        this.buttons.add(this.spectator);
+        this.buttons.add(this.renderPath);
+        this.buttons.add(this.sync);
+        this.buttons.add(this.flight);
+        this.buttons.add(this.displayPosition);
+        
+        /* Show tp buttons if in multiplayer */
+        if (!Minecraft.getMinecraft().isSingleplayer())
+        {
+    			this.buttons.add(this.minecrafttpTeleport);
+    			this.buttons.add(this.tpTeleport);
+        }
+        
+        for (GuiButton button : this.buttons.buttons)
+        {
+            this.max = Math.max(this.max, button.width);
+        }
 
         for (GuiButton button : this.buttons.buttons)
         {
@@ -118,12 +121,9 @@ public class GuiConfigCameraOptions extends AbstractGuiConfigOptions
         this.sync.setIsChecked(this.editor.syncing);
         this.flight.setIsChecked(this.editor.flight.enabled);
         this.displayPosition.setIsChecked(this.editor.displayPosition);
-
-        if (this.minecrafttpTeleport != null)
-        {
-            this.minecrafttpTeleport.setIsChecked(Aperture.proxy.config.minecrafttp_teleport);
-            this.tpTeleport.setIsChecked(Aperture.proxy.config.tp_teleport);
-        }
+        this.minecrafttpTeleport.setIsChecked(Aperture.proxy.config.minecrafttp_teleport);
+        this.tpTeleport.setIsChecked(Aperture.proxy.config.tp_teleport);
+        
     }
 
     @Override

--- a/src/main/java/mchorse/aperture/client/gui/config/GuiConfigCameraOptions.java
+++ b/src/main/java/mchorse/aperture/client/gui/config/GuiConfigCameraOptions.java
@@ -5,7 +5,6 @@ import mchorse.aperture.ClientProxy;
 import mchorse.aperture.client.gui.GuiCameraEditor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
-import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.resources.I18n;
 import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.client.config.GuiCheckBox;

--- a/src/main/java/mchorse/aperture/config/ApertureConfig.java
+++ b/src/main/java/mchorse/aperture/config/ApertureConfig.java
@@ -67,7 +67,7 @@ public class ApertureConfig
     public String camera_path_default_interp;
 
     /**
-     * Allows you to rebind /camera command's name (if you want to type less) 
+     * Allows you to rebind /camera command's name (if you want to type less)
      */
     public String camera_command_name;
 
@@ -77,7 +77,7 @@ public class ApertureConfig
     public boolean camera_simulate_velocity;
 
     /**
-     * Camera debug ticks 
+     * Camera debug ticks
      */
     public boolean camera_debug_ticks;
 
@@ -95,6 +95,16 @@ public class ApertureConfig
      * Render a custom mouse pointer in GUIs
      */
     public boolean gui_render_mouse;
+
+    /**
+     * Use "/minecraft:tp" in multiplayer's playback?
+     */
+    public boolean minecrafttp_teleport;
+
+    /**
+     * Use "/tp" in multiplayer's playback?
+     */
+    public boolean tp_teleport;
 
     /* Non conifg option stuff */
 
@@ -132,6 +142,8 @@ public class ApertureConfig
         this.camera_debug_ticks = this.config.getBoolean("camera_debug_ticks", camera, false, "Write ticks to the log during camera playback", prefix + "camera_debug_ticks");
         this.camera_first_tick_zero = this.config.getBoolean("camera_first_tick_zero", camera, false, "When camera runner starts, start the actual playback when partial tick is exactly zero", prefix + "camera_first_tick_zero");
         this.camera_profile_render = this.config.getBoolean("camera_profile_render", camera, true, "Render camera profile in the world?", prefix + "camera_profile_render");
+        this.minecrafttp_teleport = this.config.getBoolean("minecrafttp_teleport", camera, true, "When start the camera playback in multiplayer, teleport you with /minecraft:tp command (For Essentials)", prefix + "minecrafttp_teleport");
+        this.tp_teleport = this.config.getBoolean("tp_teleport", camera, true, "When start the camera playback in multiplayer, teleport you with /tp command (For Vanilla or Forge)", prefix + "tp_teleport");
 
         /* Processing camera command name */
         this.camera_command_name = this.camera_command_name.trim().replaceAll("[^\\w\\d_\\-]+", "");

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -5,7 +5,7 @@
         "description": "Enhanced camera mod",
         "version": "${version}",
         "mcversion": "${mcversion}",
-        "updateJSON": "https://raw.githubusercontent.com/ycwei982/aperture/master/version.json",
+        "updateJSON": "https://raw.githubusercontent.com/mchorse/aperture/master/version.json",
         "url": "https://github.com/mchorse/aperture",
         "authorList": ["mchorse"],
         "credits": "Badr"

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -5,6 +5,7 @@
         "description": "Enhanced camera mod",
         "version": "${version}",
         "mcversion": "${mcversion}",
+        "updateJSON": "https://raw.githubusercontent.com/ycwei982/aperture/master/version.json",
         "url": "https://github.com/mchorse/aperture",
         "authorList": ["mchorse"],
         "credits": "Badr"

--- a/version.json
+++ b/version.json
@@ -1,12 +1,26 @@
 {
 	"homepage": "https://minecraft.curseforge.com/projects/aperture",
 	"1.10.2": {
-		"1.2": "I am testing the update checker lelelelelel, this is 1.2",
-		"1.1": "I am testing the update checker lelelelelel, this is 1.1",
-		"1.0.1": "I am testing the update checker lelelelelel, this is 1.0.1"
+		"1.1": "This update fixes a lot of issues and adds few features to camera editor, and introduces camera modifiers. Camera modifiers are special camera behavior modifiers which can be added to camera fixtures. They can process fixture's output in a lot of different ways like shaking camera, looking or following an entity (while still be in the path), apply math formulas and much more!",
+		"1.0.1": "This is a small patch update that aims to improve capabilities of the camera editor by adding some new features and fixing some bugs.",
+    "1.0": "First release of Aperture mod. This release has everything Blockbuster cameras had but more. It includes its own camera editor, and stuff that other camera mods has. Its all features are frame based, meaning this camera mod would work perfectly with Minema mod and without it."
 	},
+  "1.11.2": {
+    "1.1": "This update fixes a lot of issues and adds few features to camera editor, and introduces camera modifiers. Camera modifiers are special camera behavior modifiers which can be added to camera fixtures. They can process fixture's output in a lot of different ways like shaking camera, looking or following an entity (while still be in the path), apply math formulas and much more!",
+    "1.0.1": "This is a small patch update that aims to improve capabilities of the camera editor by adding some new features and fixing some bugs.",
+    "1.0": "First release of Aperture mod. This release has everything Blockbuster cameras had but more. It includes its own camera editor, and stuff that other camera mods has. Its all features are frame based, meaning this camera mod would work perfectly with Minema mod and without it."
+  },
+  "1.12": {
+    "1.1": "This update fixes a lot of issues and adds few features to camera editor, and introduces camera modifiers. Camera modifiers are special camera behavior modifiers which can be added to camera fixtures. They can process fixture's output in a lot of different ways like shaking camera, looking or following an entity (while still be in the path), apply math formulas and much more!",
+    "1.0.1": "This is a small patch update that aims to improve capabilities of the camera editor by adding some new features and fixing some bugs.",
+    "1.0": "First release of Aperture mod. This release has everything Blockbuster cameras had but more. It includes its own camera editor, and stuff that other camera mods has. Its all features are frame based, meaning this camera mod would work perfectly with Minema mod and without it."
+  },
 	"promos": {
-		"1.10.2-latest": "1.2",
-		"1.10.2-recommended": "1.2"
+		"1.10.2-latest": "1.1",
+		"1.10.2-recommended": "1.1",
+    "1.11.2-latest": "1.1",
+    "1.11.2-recommended": "1.1",
+    "1.12-latest": "1.1",
+    "1.12-recommended": "1.1"
 	}
 }

--- a/version.json
+++ b/version.json
@@ -1,0 +1,12 @@
+{
+	"homepage": "https://minecraft.curseforge.com/projects/aperture",
+	"1.10.2": {
+		"1.2": "I am testing the update checker lelelelelel, this is 1.2",
+		"1.1": "I am testing the update checker lelelelelel, this is 1.1",
+		"1.0.1": "I am testing the update checker lelelelelel, this is 1.0.1"
+	},
+	"promos": {
+		"1.10.2-latest": "1.2",
+		"1.10.2-recommended": "1.2"
+	}
+}


### PR DESCRIPTION
Reported by **Ghost_chu**

Since Essentials removed the native teleporting with *real* position in `/tp` (use `/minecraft:tp` instead).