### PR TITLE
Fixed a minor typo in RU Keys

### DIFF
--- a/help/ru_RU/keys.yml
+++ b/help/ru_RU/keys.yml
@@ -18,7 +18,7 @@ key.aperture:
         stepFront: Шаг вперед
         stepBack: Шаг назад
         
-        rotateUp: Вразение вверх
+        rotateUp: Вращение вверх
         rotateDown: Вращение вниз
         rotateLeft: Вращение влево
         rotateRight: Вращение вправо


### PR DESCRIPTION
```rotateUp: Вразение вверх``` goes to ```rotateUp: Вращение вверх```