### PR TITLE
Trackerv2

### DIFF
--- a/src/main/java/mchorse/aperture/Aperture.java
+++ b/src/main/java/mchorse/aperture/Aperture.java
@@ -29,7 +29,7 @@ import org.lwjgl.input.Keyboard;
  *
  * This mod provides a lot of tools related to camera.
  */
-@Mod(modid = Aperture.MOD_ID, name = Aperture.MODNAME, version = Aperture.VERSION, dependencies = "required-after:mclib@[%MCLIB%,)", updateJSON = "https://raw.githubusercontent.com/mchorse/aperture/1.12/version.json")
+@Mod(modid = Aperture.MOD_ID, name = Aperture.MODNAME, version = Aperture.VERSION, dependencies = "after:minema@[%MINEMA%,);required-after:mclib@[%MCLIB%,)", updateJSON = "https://raw.githubusercontent.com/mchorse/aperture/1.12/version.json")
 public class Aperture
 {
     /* Mod info */

--- a/src/main/java/mchorse/aperture/camera/CameraExporter.java
+++ b/src/main/java/mchorse/aperture/camera/CameraExporter.java
@@ -5,6 +5,7 @@ import com.google.common.collect.HashBiMap;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import info.ata4.minecraft.minema.CaptureSession;
 import info.ata4.minecraft.minema.Minema;
 import info.ata4.minecraft.minema.MinemaAPI;
 import info.ata4.minecraft.minema.client.event.MinemaEventbus;
@@ -26,9 +27,12 @@ import org.lwjgl.opengl.GL11;
 
 import javax.vecmath.Matrix4d;
 import javax.vecmath.Vector3d;
-import java.io.FileWriter;
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.DoubleBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -542,7 +546,7 @@ public class CameraExporter
     {
         try
         {
-            FileWriter file = new FileWriter(MinemaAPI.getCapturePath().toURI().getPath() + filename);
+            BufferedWriter file = Files.newBufferedWriter(Paths.get(CaptureSession.singleton.getCaptureDir().toUri().toString().replace("file:///", "") + filename), StandardCharsets.UTF_8);
 
             file.write(this.wrapper.toString());
             file.close();


### PR DESCRIPTION
- multiple equal entity names for entity tracking with the entity selector are now possible. It will remap the names to indexed names likes “name, name.1, name.2”
- Changed the functionality of combine tracker morphs. It is now the option “automatic append”. If the tracker morph’s name already was tracked, it will check if this tracker starts at the next frame where the original tracker has stopped. If it continues at the next frame, it then appends this tracking data to the original one.
- Motion Blur frames are now internally ignored. The tracking data only includes the actual video frames now.
- fixed heldframes - the tracker now tracks the last heldframe which fixes tracking inconsistencies when using for example drag modifier
- fixed morph trackers not working when use target is not enabled
- Added Minema as optional dependency with a required minimum version. The required minimum version is 3.6.2
- made tracking file UTF 8